### PR TITLE
Add GitHub Linguist support for Sentra language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,51 @@
+# Linguist language detection for Sentra
+# Mark .sn and .sentra files as Sentra language
+*.sn linguist-language=Sentra
+*.sentra linguist-language=Sentra
+
+# Mark Sentra files as detectable (not vendored or generated)
+*.sn linguist-detectable=true
+*.sentra linguist-detectable=true
+
+# Ensure Sentra files are not marked as documentation
+*.sn linguist-documentation=false
+*.sentra linguist-documentation=false
+
+# Mark vendor directories
+vendor/* linguist-vendored
+dist/* linguist-generated
+bin/* linguist-generated
+
+# Mark documentation files
+docs/* linguist-documentation
+*.md linguist-documentation
+
+# Override specific important files to be included
+README.md linguist-documentation=false
+README_SENTRA.md linguist-documentation=false
+
+# Ensure examples are detected as Sentra code
+examples/**/*.sn linguist-detectable=true
+examples/**/*.sn linguist-documentation=false
+
+# Ensure test files are detected
+tests/**/*.sn linguist-detectable=true
+test-project/**/*.sn linguist-detectable=true
+test-sentra-project/**/*.sn linguist-detectable=true
+
+# Override detection - treat all Go files as vendored
+*.go linguist-vendored
+internal/**/*.go linguist-vendored
+cmd/**/*.go linguist-vendored
+
+# Except the module files
+go.mod -linguist-vendored
+go.sum -linguist-vendored
+
+# Force Sentra as primary language
+*.sn linguist-language=Sentra linguist-detectable
+*.sentra linguist-language=Sentra linguist-detectable
+
+# Count all Sentra files
+**/*.sn linguist-detectable
+**/*.sentra linguist-detectable

--- a/.github/samples/example.sn
+++ b/.github/samples/example.sn
@@ -1,0 +1,53 @@
+// Sentra Security Language Example
+// This file helps GitHub recognize Sentra language patterns
+
+import security
+import network
+import siem
+
+// Security configuration structure
+struct SecurityConfig {
+    scan_interval int
+    threat_threshold float
+    enable_logging bool
+    alert_channels []string
+}
+
+// Threat detection function
+fn detect_threats(config SecurityConfig) {
+    let scanner = security.new_scanner(config)
+    
+    // Continuous monitoring loop
+    while true {
+        let threats = scanner.scan()
+        
+        for threat in threats {
+            if threat.severity >= config.threat_threshold {
+                siem.log_event({
+                    type: "threat_detected",
+                    severity: threat.severity,
+                    details: threat
+                })
+                
+                // Send alerts through configured channels
+                for channel in config.alert_channels {
+                    security.alert(channel, threat)
+                }
+            }
+        }
+        
+        time.sleep(config.scan_interval)
+    }
+}
+
+// Main entry point
+fn main() {
+    let config = SecurityConfig{
+        scan_interval: 60,
+        threat_threshold: 7.5,
+        enable_logging: true,
+        alert_channels: ["email", "slack", "siem"]
+    }
+    
+    detect_threats(config)
+}

--- a/.github/sentra-linguist.yml
+++ b/.github/sentra-linguist.yml
@@ -1,0 +1,23 @@
+# Sentra Language Specification for GitHub Linguist
+# This file should be submitted to https://github.com/github/linguist
+# to get official language recognition on GitHub
+
+Sentra:
+  type: programming
+  color: "#FF6B35"  # Security-themed orange color
+  extensions:
+    - ".sn"
+    - ".sentra"
+  tm_scope: source.sentra
+  ace_mode: text
+  language_id: 213853887  # Generated via SHA256 hash
+  aliases:
+    - sn
+  interpreters:
+    - sentra
+  group: Security
+  codemirror_mode: go  # Similar syntax highlighting
+  codemirror_mime_type: text/x-sentra
+  wrap: true
+  filenames:
+    - sentra.mod


### PR DESCRIPTION
- Add .gitattributes to configure language detection
- Mark .sn and .sentra files as Sentra language
- Hide Go implementation files from language stats
- Add language specification with security-themed orange color (#FF6B35)
- Include sample code for pattern recognition
- Set language ID to 213853887 (SHA256 hash-based)